### PR TITLE
Support for SSL_set_mode

### DIFF
--- a/buildAll_config.py
+++ b/buildAll_config.py
@@ -9,7 +9,7 @@ import subprocess
 
 # The build scripts expect the OpenSSL and Zlib src packages
 # to be in nassl's root folder
-OPENSSL_DIR =   join(getcwd(), 'openssl-1.0.1i')
+OPENSSL_DIR =   join(getcwd(), 'openssl-1.0.1j')
 # Warning: use a fresh Zlib src tree on Windows or build will fail
 # ie. do not use the same Zlib src folder for Windows and Unix build
 ZLIB_DIR =      join(getcwd(), 'zlib-1.2.8')

--- a/src/SslClient.py
+++ b/src/SslClient.py
@@ -297,3 +297,6 @@ class SslClient(object):
         else:
             return None
 
+    def set_mode(self, mode):
+        return self._ssl.set_mode(mode)
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -20,6 +20,10 @@ TLSV1_1 = 4
 TLSV1_2 = 5
 
 
+# SSL mode constants
+SSL_MODE_SEND_FALLBACK_SCSV =       0x00000080L
+
+
 # Certificate and private key formats
 SSL_FILETYPE_PEM =  1
 SSL_FILETYPE_ASN1 = 2

--- a/src/_nassl/nassl_SSL.c
+++ b/src/_nassl/nassl_SSL.c
@@ -107,6 +107,18 @@ static PyObject* nassl_SSL_set_connect_state(nassl_SSL_Object *self, PyObject *a
 }
 
 
+static PyObject* nassl_SSL_set_mode(nassl_SSL_Object *self, PyObject *args) {
+    long mode;
+
+    if (!PyArg_ParseTuple(args, "l", &mode)) {
+        return NULL;
+    }
+
+    SSL_set_mode(self->ssl, mode);
+    Py_RETURN_NONE;
+}
+
+
 static PyObject* nassl_SSL_do_handshake(nassl_SSL_Object *self, PyObject *args) {
     int result = SSL_do_handshake(self->ssl);
     if (result != 1) {
@@ -711,6 +723,9 @@ static PyMethodDef nassl_SSL_Object_methods[] = {
     },
     {"set_connect_state", (PyCFunction)nassl_SSL_set_connect_state, METH_NOARGS,
      "OpenSSL's SSL_set_connect_state()."
+    },
+    {"set_mode", (PyCFunction)nassl_SSL_set_mode, METH_VARARGS,
+     "OpenSSL's SSL_set_mode()."
     },
     {"read", (PyCFunction)nassl_SSL_read, METH_VARARGS,
      "OpenSSL's SSL_read()."


### PR DESCRIPTION
This pull request adds support for the SSL_set_mode method used to set the TLS_FALLBACK_SCSV signaling cipher suite value introduced in OpenSSL 1.0.1j for preventing protocol downgrade attacks.
http://tools.ietf.org/html/draft-ietf-tls-downgrade-scsv-00