### PR TITLE
Option to ignore client certificate requests

### DIFF
--- a/setup_unix.py
+++ b/setup_unix.py
@@ -19,7 +19,7 @@ unix_ext_args.update({
     'include_dirs' : [OPENSSL_INSTALL_DIR + '/include'],
     'extra_compile_args' : extra_compile_args,
     'library_dirs' : [OPENSSL_DIR, ZLIB_DIR],
-    'libraries' : ['ssl', 'z', 'crypto']})
+    'libraries' : ['ssl', 'crypto', 'z']})
 
 
 unix_setup = NASSL_SETUP.copy()

--- a/src/SslClient.py
+++ b/src/SslClient.py
@@ -37,7 +37,7 @@ class SslClient(object):
     """
 
 
-    def __init__(self, sock=None, sslVersion=SSLV23, sslVerify=SSL_VERIFY_PEER, sslVerifyLocations=None):
+    def __init__(self, sock=None, sslVersion=SSLV23, sslVerify=SSL_VERIFY_PEER, sslVerifyLocations=None, ignoreClientCertificateRequests=False):
         # A Python socket handles transmission of the data
         self._sock = sock
         self._handshakeDone = False
@@ -48,6 +48,9 @@ class SslClient(object):
         self._sslCtx.set_verify(sslVerify)
         if sslVerifyLocations:
             self._sslCtx.load_verify_locations(sslVerifyLocations)
+
+        if ignoreClientCertificateRequests:
+            self._sslCtx.ignore_certificate_requests(1)
 
         # SSL
         self._ssl = SSL(self._sslCtx)

--- a/src/_nassl/nassl_SSL_CTX.c
+++ b/src/_nassl/nassl_SSL_CTX.c
@@ -185,6 +185,24 @@ static PyObject* nassl_SSL_CTX_set_private_key_password(nassl_SSL_CTX_Object *se
     Py_RETURN_NONE;
 }
 
+static PyObject* nassl_SSL_CTX_ignore_certificate_requests(nassl_SSL_CTX_Object *self, PyObject *args) {
+    int ignoreRequests = 0;
+
+    if(!PyArg_ParseTuple(args, "i", &ignoreRequests)) {
+        return NULL;
+    }
+
+    if(ignoreRequests) {
+        SSL_CTX_set_client_cert_cb(self->sslCtx, NULL);
+    } else {
+        SSL_CTX_set_client_cert_cb(self->sslCtx, client_cert_cb);
+    }
+
+    self->ignoreClientCertRequests = ignoreRequests;
+
+    Py_RETURN_NONE;
+}
+
 
 static PyMethodDef nassl_SSL_CTX_Object_methods[] = {
     {"set_verify", (PyCFunction)nassl_SSL_CTX_set_verify, METH_VARARGS,
@@ -195,6 +213,9 @@ static PyMethodDef nassl_SSL_CTX_Object_methods[] = {
     },
     {"set_private_key_password", (PyCFunction)nassl_SSL_CTX_set_private_key_password, METH_VARARGS,
      "Sets up a default callback for encrypted PEM file handling using OpenSSL's SSL_CTX_set_default_passwd_cb() with a hardcoded callback, and then stores the supplied password to be used for subsequent PEM decryption operations."
+    },
+    {"ignore_certificate_requests", (PyCFunction)nassl_SSL_CTX_ignore_certificate_requests, METH_VARARGS,
+     "Ignore client certificate requests from the server and continue even if no certificate was provided."
     },
     {NULL}  // Sentinel
 };

--- a/src/_nassl/nassl_SSL_CTX.h
+++ b/src/_nassl/nassl_SSL_CTX.h
@@ -5,6 +5,7 @@ typedef struct {
     PyObject_HEAD
     SSL_CTX *sslCtx; // OpenSSL SSL_CTX C struct
     char *pkeyPasswordBuf; // Buffer where the passcode to unlock the private key will be stored
+    int ignoreClientCertRequests; // continue even if client certificate is missing
 } nassl_SSL_CTX_Object;
 
 // Type needs to be accessible to nassl_SSL.c


### PR DESCRIPTION
Allows to continue even if the server requests a client certificate.

Useful for servers with optional client certificate authentication.