### PR TITLE
Compatibility for systems which have python3 installed as default python

### DIFF
--- a/buildAll_unix.py
+++ b/buildAll_unix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 from platform import architecture, mac_ver
 from sys import platform
 from os.path import join
@@ -72,7 +72,7 @@ def main():
 
     # Test nassl
     NASSL_TEST_TASKS = [
-        'python -m unittest discover --pattern=*_Tests.py']
+        'python2 -m unittest discover --pattern=*_Tests.py']
 
     perform_build_task('NASSL Tests', NASSL_TEST_TASKS, TEST_DIR)
 

--- a/src/DebugSslClient.py
+++ b/src/DebugSslClient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 from nassl._nassl import SSL
 from SslClient import SslClient
 

--- a/src/OcspResponse.py
+++ b/src/OcspResponse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 
 class OcspResponse:

--- a/src/SslClient.py
+++ b/src/SslClient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 from nassl._nassl import SSL_CTX, SSL, BIO, WantReadError, OpenSSLError, X509, WantX509LookupError
 from nassl import SSLV23, SSLV2, SSL_VERIFY_PEER, TLSEXT_STATUSTYPE_ocsp
 from X509Certificate import X509Certificate

--- a/src/X509Certificate.py
+++ b/src/X509Certificate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 from binascii import hexlify
 import re
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 
 NASSL_VERSION = "1.0 DEV"


### PR DESCRIPTION
This is done by simply changing the first line in *.py files to invoke:
```/usr/bin/python2```

This most likely needs some testing on other systems before merging, but is working great for me on Arch Linux (using sslyze-git AUR package).
