### PR TITLE
Change python invocation to python2.7 in buildAll_unix.py

### DIFF
--- a/buildAll_unix.py
+++ b/buildAll_unix.py
@@ -64,7 +64,7 @@ def main():
 
     # Build nassl
     NASSL_BUILD_TASKS = [
-        'python setup_unix.py build',
+        'python2.7 setup_unix.py build',
         'cp -R ' + NASSL_INSTALL_DIR + '* ' + TEST_DIR]
 
     perform_build_task('NASSL', NASSL_BUILD_TASKS)


### PR DESCRIPTION
Changing python to python2.7 in order to close #29 and establish full compatibility for systems which have python3 installed as default alongside python2.