### PR TITLE
Bug fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ of the source package to nassl/zlib-1.2.8.
 Build script for OS X 64 bits and Linux 32/64 bits. It was tested on OS X
 Mavericks, Ubuntu 13.04 and Debian 7. This is the easiest build script to use.
 
-    wget http://zlib.net/zlib-1.2.8.tar.gz
-    tar xvfz  zlib-1.2.8.tar.gz
-    wget http://www.openssl.org/source/old/1.0.2/openssl-1.0.2a.tar.gz
-    tar xvfz  openssl-1.0.2a.tar.gz
-    python buildAll_unix.py
+    $ wget http://zlib.net/zlib-1.2.8.tar.gz
+    $ tar xvfz  zlib-1.2.8.tar.gz
+    $ wget http://www.openssl.org/source/old/1.0.2/openssl-1.0.2a.tar.gz
+    $ tar xvfz  openssl-1.0.2a.tar.gz
+    $ python buildAll_unix.py
 
 
 ### buildAll_win32.py
@@ -56,7 +56,7 @@ from openssl/out32 to the right location in build/. Look at win32 builds.
 Unit Tests
 ----------
 
-    python -m unittest discover test -p *Tests.py
+    $ python -m unittest discover test -p *Tests.py
 
 
 Structure

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Mavericks, Ubuntu 13.04 and Debian 7. This is the easiest build script to use.
 
     wget http://zlib.net/zlib-1.2.8.tar.gz
     tar xvfz  zlib-1.2.8.tar.gz
-    wget https://www.openssl.org/source/openssl-1.0.2a.tar.gz
+    wget http://www.openssl.org/source/old/1.0.2/openssl-1.0.2a.tar.gz
     tar xvfz  openssl-1.0.2a.tar.gz
     python buildAll_unix.py
 

--- a/src/X509Certificate.py
+++ b/src/X509Certificate.py
@@ -79,7 +79,8 @@ class X509Certificate:
             if self._dnsname_match(commonName, hostname):
                 return X509_NAME_MATCHES_CN
         except KeyError: # No CN either ? This certificate is malformed
-            raise X509HostnameValidationError("Certificate has no subjectAltName and no Common Name; malformed certificate ?")
+            pass
+            #raise X509HostnameValidationError("Certificate has no subjectAltName and no Common Name; malformed certificate ?")
 
         return X509_NAME_MISMATCH
 


### PR DESCRIPTION
 X509_NAME_MISMATCH returns when certificate has no 'common name' in matched_hostname()