### PR TITLE
Fixes issue where _use_private_key tries to get the value variable fr…

### DIFF
--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -99,7 +99,7 @@ class SslClient(object):
             self._ssl_ctx.load_verify_locations(ssl_verify_locations)
 
         if client_certchain_file is not None:
-            self._use_private_key(client_certchain_file, client_key_file, client_key_type.value, client_key_password)
+            self._use_private_key(client_certchain_file, client_key_file, client_key_type, client_key_password)
 
         if ignore_client_authentication_requests:
             if client_certchain_file:


### PR DESCRIPTION
…om client_key_type.value

_use_private_key expects a client_key_type but instead it is passed the value, which it tries to then get the value of