### PR TITLE
Added Early-Data test, sample early data client and add set_max_early…

### DIFF
--- a/nassl/_nassl/nassl_SSL_SESSION.c
+++ b/nassl/_nassl/nassl_SSL_SESSION.c
@@ -32,6 +32,22 @@ static PyObject* nassl_SSL_SESSION_as_text(nassl_SSL_SESSION_Object *self)
 }
 
 #ifndef LEGACY_OPENSSL
+static PyObject* nassl_SSL_SESSION_set_max_early_data(nassl_SSL_SESSION_Object *self, PyObject *args)
+{
+    int max_early_data = 0;
+
+    if (!PyArg_ParseTuple(args, "I", &max_early_data))
+    {
+        return NULL;
+    }
+
+    if (self->sslSession != NULL) {
+        SSL_SESSION_set_max_early_data(self->sslSession, max_early_data);
+    }
+
+    return Py_BuildValue("I", max_early_data);
+}
+
 static PyObject* nassl_SSL_SESSION_get_max_early_data(nassl_SSL_SESSION_Object *self, PyObject *args)
 {
     int returnValue = 0;
@@ -50,6 +66,9 @@ static PyMethodDef nassl_SSL_SESSION_Object_methods[] =
      "OpenSSL's SSL_SESSION_print()."
     },
 #ifndef LEGACY_OPENSSL
+    {"set_max_early_data", (PyCFunction)nassl_SSL_SESSION_set_max_early_data, METH_VARARGS,
+     "OpenSSL's SSL_SESSION_set_max_early_data()."
+    },
     {"get_max_early_data", (PyCFunction)nassl_SSL_SESSION_get_max_early_data, METH_NOARGS,
      "OpenSSL's SSL_SESSION_get_max_early_data()."
     },

--- a/sample_client_early_data.py
+++ b/sample_client_early_data.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from nassl.ssl_client import OpenSslVersionEnum, SslClient, OpenSslEarlyDataStatusEnum, OpenSslVerifyEnum
+import socket
+
+
+class EarlyDataClient():
+    def __init__(self, **kw):
+        self.socket = None
+        self.session = None
+        self.client = None
+
+        self.dest = kw.get('dest', 'localhost')
+        self.port = kw.get('port', 443)
+        self.socket_timeout = kw.get('socket_timeout', 5)
+        self.regular_data = kw.get('regular_data', b'XXX-REGULAR-DATA-XXX')
+        self.early_data = kw.get('early_data', b'XXX-EARLY-DATA-XXX')
+        self.read_size = kw.get('read_size', 2048)
+
+    def _init(self, dest='localhost', port=443, timeout=5):
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.settimeout(timeout)
+        self.socket.connect((dest, port))
+        self.client = SslClient(ssl_version=OpenSslVersionEnum.TLSV1_3, underlying_socket=self.socket,
+                           ssl_verify_locations=u'mozilla.pem')
+
+    def _finish_handshake(self):
+        if not self.client.is_handshake_completed():
+            self.client.do_handshake()
+            print('\tCipher suite:', self.client.get_current_cipher_name())
+
+    def _close(self):
+        self.client.shutdown()
+        self.socket.close()
+        print('\n')
+
+    def _write_read_close(self, data_to_send=b'XXX-REGULAR-DATA-XXX', read_size=2048):
+        try:
+            self.client.write(data_to_send)
+            self.client.read(2048)
+            self.session = self.client.get_session()
+        except socket.timeout as e:
+            print('\n\tSocket was timed out. Closing...')
+        finally:
+            self._close()
+
+    def _send_early_data(self, early_data_to_send=b'XXX-EARLY-DATA-XXX'):
+        self.client.set_session(self.session)
+        self.client.write_early_data(early_data_to_send)
+        self._finish_handshake()
+        print('\t', self.client.get_early_data_status())
+        self._close()
+
+    def test_early(self, early_data_to_send=b'XXX-EARLY-DATA-XXX'):
+        print('First Session:')
+        self._init(dest=self.dest, port=self.port)
+        self._finish_handshake()
+        self._write_read_close(data_to_send=self.regular_data)
+        
+        if self.session:
+            print('Reused Session:')
+            self._init(dest=self.dest, port=self.port)
+            if self.session.get_max_early_data() > 0:
+                self._send_early_data()
+            else:
+                print('\n\tServer does not support Early-Data. Closing...')
+                self._close
+        else:
+            print('\nPrevious session failed, can`t send early data. Closing...')
+
+        print('='*80, '\n')
+
+
+if __name__ == '__main__':
+    print('='*80, '\n')
+
+    '''
+    # To run the test localy, just use openssl s_server (locally) as follows (linux only):
+    # while [ 1 ]; do echo "1"; done | ./openssl s_server -accept 8443 -early_data
+
+    print('='*5, 'Check against local server', '='*5)
+    ed_client = EarlyDataClient(port=8443)
+    ed_client.test_early()
+    '''
+
+    print('='*5, 'Check against tls13.baishancloud.com:44344', '='*5)
+    ed_client = EarlyDataClient(dest='tls13.baishancloud.com', port=44344, 
+        regular_data=b'GET / HTTP/1.1\r\nUser-Agent: Test\r\nHost: tls13.baishancloud.com:44344\r\n\r\n')
+    ed_client.test_early()

--- a/tests/ssl_client_tests.py
+++ b/tests/ssl_client_tests.py
@@ -6,6 +6,7 @@ import unittest
 import socket
 import tempfile
 
+from nassl._nassl import OpenSSLError
 from nassl.legacy_ssl_client import LegacySslClient
 from nassl.ssl_client import ClientCertificateRequested, OpenSslVersionEnum, OpenSslVerifyEnum, OpenSslFileTypeEnum, \
     SslClient
@@ -209,7 +210,6 @@ class LegacySslClientOnlineClientAuthenticationTests(CommonSslClientOnlineClient
 
 
 class ModernSslClientOnlineTls13Tests(unittest.TestCase):
-
     def test_tls_1_3(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(10)
@@ -218,9 +218,61 @@ class ModernSslClientOnlineTls13Tests(unittest.TestCase):
                                ssl_verify=OpenSslVerifyEnum.NONE)
         self.assertTrue(ssl_client)
 
+class ModernSslClientOnlineEarlyDataTests(unittest.TestCase):
+
+    _DATA_TO_SEND = 'GET / HTTP/1.1\r\nHost: tls13.crypto.mozilla.org\r\n\r\n'
+
+    def setUp(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(10)
+        #sock.connect(('tls13.crypto.mozilla.org', 443))
+        sock.connect(('tls13.baishancloud.com', 44344))
+        ssl_client = SslClient(ssl_version=OpenSslVersionEnum.TLSV1_3, underlying_socket=sock,
+                               ssl_verify=OpenSslVerifyEnum.NONE)
+        self.ssl_client = ssl_client
+
+    def tearDown(self):
+        self.ssl_client.shutdown()
+        self.ssl_client.get_underlying_socket().close()
+
+    def test_write_early_data_doesnot_finish_handshake(self):
+        self.ssl_client.do_handshake()
+        self.ssl_client.write(self._DATA_TO_SEND);
+        self.ssl_client.read(2048) 
+        sess = self.ssl_client.get_session()
+        self.assertIsNotNone(sess)
+        self.tearDown()
+        self.setUp()
+        self.ssl_client.set_session(sess)
+        self.ssl_client.write_early_data(self._DATA_TO_SEND);
+        self.assertFalse(self.ssl_client.is_handshake_completed())
+
+    def test_write_early_data_fail_when_used_on_non_reused_session(self):
+        self.assertRaisesRegexp(OpenSSLError, 
+                                'function you should not call',
+                                self.ssl_client.write_early_data,
+                                self._DATA_TO_SEND)
+
+    def test_write_early_data_fail_when_trying_to_send_more_than_max_ealry_data(self):
+        self.ssl_client.do_handshake()
+        self.ssl_client.write(self._DATA_TO_SEND);
+        self.ssl_client.read(2048) 
+        sess = self.ssl_client.get_session()
+        max_early = sess.get_max_early_data()
+        str_to_send = 'GET / HTTP/1.1\r\nData: {}\r\n\r\n'
+        self.assertIsNotNone(sess)
+        self.tearDown()
+        self.setUp()
+        self.ssl_client.set_session(sess)
+        self.assertRaisesRegexp(OpenSSLError, 
+                                'too much early data',
+                                self.ssl_client.write_early_data,
+                                str_to_send.format('*' * max_early))
+
 
 def main():
     unittest.main()
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
Hi,
Added tests for early data and a sample client to show a simple use of early data.
Also added another SSL_SESSION API wrapper called set_max_early_data
**Please dont approve this PR until updating the modern openssl libraries to support draft-22.** 
I commited my chages while openssl master repo had b44a65512a4a0a299f8f817b63df472e74a0007a as the last commit.

Thanks!