### PR TITLE
Changing hard-coded python location

### DIFF
--- a/build_from_scratch.py
+++ b/build_from_scratch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """ Base script to successively build Zlib, OpenSSL and nassl from scratch.
 
 It will build the _nassl C extension for the python interpreter/platform that was used to run this script (ie. no

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals

--- a/sample_client.py
+++ b/sample_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import absolute_import

--- a/sample_client_early_data.py
+++ b/sample_client_early_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import absolute_import

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 

--- a/tests/SSL_CTX_tests.py
+++ b/tests/SSL_CTX_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals

--- a/tests/SSL_tests.py
+++ b/tests/SSL_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals

--- a/tests/X509_EXTENSION_tests.py
+++ b/tests/X509_EXTENSION_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals

--- a/tests/X509_NAME_ENTRY_tests.py
+++ b/tests/X509_NAME_ENTRY_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals

--- a/tests/X509_tests.py
+++ b/tests/X509_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals

--- a/tests/ocsp_response_tests.py
+++ b/tests/ocsp_response_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import

--- a/tests/ssl_client_tests.py
+++ b/tests/ssl_client_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals


### PR DESCRIPTION
Changing hard-coded `#!/usr/bin/python` to `#!/usr/bin/env python`.

I was having problems getting `build_from_scratch.py` to run on my local system because I'm using `pyenv`, and hence my `python` executable isn't located at `/usr/bin/python`.