### PR TITLE
Add ability to pass name_indication to invocation

### DIFF
--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -95,7 +95,7 @@ class BaseSslClient(ABC):
         client_key_type: OpenSslFileTypeEnum = OpenSslFileTypeEnum.PEM,
         client_key_password: str = "",
         ignore_client_authentication_requests: bool = False,
-        name_indication: Optional[str] = None,
+        server_name_indication: Optional[str] = None,
     ) -> None:
         self._init_base_objects(ssl_version, underlying_socket)
 
@@ -111,8 +111,8 @@ class BaseSslClient(ABC):
         )
         # Now create the SSL object
         self._init_ssl_objects()
-        if name_indication is not None:
-            self._ssl.set_tlsext_host_name(name_indication)
+        if server_name_indication is not None:
+            self._ssl.set_tlsext_host_name(server_name_indication)
 
     def _init_base_objects(self, ssl_version: OpenSslVersionEnum, underlying_socket: Optional[socket.socket]) -> None:
         """Setup the socket and SSL_CTX objects.

--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -95,6 +95,7 @@ class BaseSslClient(ABC):
         client_key_type: OpenSslFileTypeEnum = OpenSslFileTypeEnum.PEM,
         client_key_password: str = "",
         ignore_client_authentication_requests: bool = False,
+        name_indication: Optional[str] = None,
     ) -> None:
         self._init_base_objects(ssl_version, underlying_socket)
 
@@ -110,6 +111,8 @@ class BaseSslClient(ABC):
         )
         # Now create the SSL object
         self._init_ssl_objects()
+        if name_indication is not None:
+            self._ssl.set_tlsext_host_name(name_indication)
 
     def _init_base_objects(self, ssl_version: OpenSslVersionEnum, underlying_socket: Optional[socket.socket]) -> None:
         """Setup the socket and SSL_CTX objects.


### PR DESCRIPTION
This could make invocation a bit easier from the user perspective. Consider the code below:

host = "foo.com"
port = 443

soc.connect((host, port))

ssl_client = SslClient(ssl_version=OpenSslVersionEnum.SSLV23, underlying_socket=soc,
                                    ssl_verify=OpenSslVerifyEnum.NONE, _name_indication=host_)

ssl_client.do_handshake()

I get why server_name is not set by default at BaseSslClient invocation since nassl has no knowledge of the server_name from the underlying socket, but the caller does and can pass it. 

I made the name_indication optional, so that it is not a breaking change.