### PR TITLE
upgrade zlib to 1.2.13

### DIFF
--- a/build_tasks.py
+++ b/build_tasks.py
@@ -314,11 +314,11 @@ class ModernOpenSslBuildConfig(OpenSslBuildConfig):
 class ZlibBuildConfig(BuildConfig):
     @property
     def src_tar_gz_url(self) -> str:
-        return "https://zlib.net/zlib-1.2.12.tar.gz"
+        return "https://zlib.net/zlib-1.2.13.tar.gz"
 
     @property
     def src_path(self) -> Path:
-        return _DEPS_PATH / "zlib-1.2.12"
+        return _DEPS_PATH / "zlib-1.2.13"
 
     def build(self, ctx: Context) -> None:
         if self.platform in [SupportedPlatformEnum.WINDOWS_32, SupportedPlatformEnum.WINDOWS_64]:


### PR DESCRIPTION
Fixes #96 -- although it would still be better if there was a way to link to the system zlib instead.