### PR TITLE
Allow native arm64 macOS builds

### DIFF
--- a/build_tasks.py
+++ b/build_tasks.py
@@ -239,11 +239,23 @@ class LegacyOpenSslBuildConfig(OpenSslBuildConfig):
     def _openssl_git_tag(self) -> str:
         return "OpenSSL_1_0_2e"
 
+    # Note `no-asm` is necessary for macOS M* support.
+    # The linux-aarch64 target causes the build system to output GAS assembly directives, which are incompatible with
+    # the default assembler in the macOS toolchain.
+    # TODO: Since the C routines used when no-asm is passed are ostensibly less efficient than the corresponding
+    # assembly routines, we could consider only passing `no-asm` when we're building for the macOS M* target.
     _OPENSSL_CONF_CMD = (
         "perl Configure {target} zlib no-zlib-dynamic no-shared enable-rc5 enable-md2 enable-gost "
-        "enable-cast enable-idea enable-ripemd enable-mdc2 --with-zlib-include={zlib_include_path} "
+        "enable-cast enable-idea enable-ripemd enable-mdc2 no-asm --with-zlib-include={zlib_include_path} "
         "--with-zlib-lib={zlib_lib_path} {extra_args}"
     )
+
+    def _get_build_target(self, should_build_for_debug: bool) -> str:
+        # As a hack, the legacy OpenSSL build targets the linux-aarch64 platform on M* macOS
+        if self.platform == SupportedPlatformEnum.OSX_ARM64:
+            # Note there's no debug build variant available here
+            return "linux-aarch64"
+        return super()._get_build_target(should_build_for_debug)
 
     @property
     def include_path(self) -> Path:

--- a/build_tasks.py
+++ b/build_tasks.py
@@ -154,7 +154,7 @@ class OpenSslBuildConfig(BuildConfig, ABC):
         elif self.platform == SupportedPlatformEnum.OSX_64:
             openssl_target = "darwin64-x86_64-cc"
         elif self.platform == SupportedPlatformEnum.OSX_ARM64:
-            openssl_target = "arm64-x86_64-cc"
+            openssl_target = "darwin64-arm64-cc"
         elif self.platform == SupportedPlatformEnum.LINUX_64:
             openssl_target = "linux-x86_64"
         elif self.platform == SupportedPlatformEnum.LINUX_32:
@@ -277,7 +277,7 @@ class LegacyOpenSslBuildConfig(OpenSslBuildConfig):
 class ModernOpenSslBuildConfig(OpenSslBuildConfig):
     @property
     def _openssl_git_tag(self) -> str:
-        return "OpenSSL_1_1_1s"
+        return "OpenSSL_1_1_1t"
 
     _OPENSSL_CONF_CMD = (
         "perl Configure {target} zlib no-zlib-dynamic no-shared enable-rc5 enable-md2 enable-gost "


### PR DESCRIPTION
This PR resolves #83 by:
* Bumping our 'modern' OpenSSL tag to one that has an arm64 macOS target
* Using a build target in the 'legacy' OpenSSL that's compatible with arm64 macOS

One thing that I think would be better: during the build, apply a patch that adds the right build settings to the 'legacy' OpenSSL. You can see an example of this sort of thing [here](https://github.com/codyd51/axle/blob/paging-demo/scripts/gcc.patch); applying the patch is [here](https://github.com/codyd51/axle/blob/paging-demo/scripts/build_os_toolchain.py#L126-L129). In this case, we'd need to add a line similar to [this](https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/Configure#L408) that describes the desired build settings. I didn't do this for now as I didn't have much time and wasn't sure if this pull request was desired. 

Although I haven't looked at the `linux-aarch64` build settings in depth, the build completes and the test suite passes.

Let me know your thoughts, and thanks!