### PR TITLE
Fix sslyze crash on some domains in nassl handshake

### DIFF
--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -219,6 +219,9 @@ class BaseSslClient(ABC):
                 if "sslv3 alert certificate unknown" in e.args[0]:
                     # Some banking websites do that: https://github.com/nabla-c0d3/sslyze/issues/531
                     raise ClientCertificateRequested(self.get_client_CA_list())
+                if "octet invalid" in e.args[0] and 'bad signature' in e.args[0]:
+                    # Fix sslyze crash on some domains where we have "first octet invalid" and "bad signature" error or "last octet invalide" and "bad signature" error
+                    raise ClientCertificateRequested(self.get_client_CA_list())
                 else:
                     raise
 


### PR DESCRIPTION
This pull request fixes two blocking errors in **nassl** that occur when running sslyze on certain domain names. 
When the "last octet invalid" and "bad signature" errors occur together, or when the "first octet invalid" and "bad signature" errors occur together, the thread stops and the SoftTimeLimitExceeded error is thrown on our threads.


```
Exception in thread Thread-3:
Traceback (most recent call last):
...
File "/home/***/.venv/***/lib/python3.10/site-packages/nassl/ssl_client.py", line 194, in do_handshake
    self._ssl.do_handshake()
nassl._nassl.OpenSSLError: error:0407E086:rsa routines:RSA_verify_PKCS1_PSS_mgf1:last octet invalid
error:1417B07B:SSL routines:tls_process_cert_verify:bad signature
```

I have forked the project and made the necessary change to fix these errors. 

These changes should prevent the blocking errors from occurring and allow sslyze to run successfully on certain domain names. I have tested these changes locally and they appear to be working as expected.

