### PR TITLE
Add set_sigalgs to ssl_client / get_peer_signature_nid to set key exchange params

### DIFF
--- a/nassl/_nassl/nassl_SSL.c
+++ b/nassl/_nassl/nassl_SSL.c
@@ -813,6 +813,24 @@ static PyObject* nassl_SSL_set_ciphersuites(nassl_SSL_Object *self, PyObject *ar
 }
 
 
+// SSL_set1_sigalgs_list() is only available in OpenSSL 1.1.1
+static PyObject* nassl_SSL_set1_sigalgs_list(nassl_SSL_Object *self, PyObject *args)
+{
+    char *sigalgList;
+    if (!PyArg_ParseTuple(args, "s", &sigalgList))
+    {
+        return NULL;
+    }
+
+    if (!SSL_set1_sigalgs_list(self->ssl, sigalgList))
+    {
+        return raise_OpenSSL_error();
+    }
+
+    Py_RETURN_NONE;
+}
+
+
 static PyObject* nassl_SSL_get0_verified_chain(nassl_SSL_Object *self, PyObject *args)
 {
     STACK_OF(X509) *verifiedCertChain = NULL;
@@ -1180,6 +1198,9 @@ static PyMethodDef nassl_SSL_Object_methods[] =
     },
     {"set_ciphersuites", (PyCFunction)nassl_SSL_set_ciphersuites, METH_VARARGS,
      "OpenSSL's SSL_set_ciphersuites()."
+    },
+    {"set1_sigalgs_list", (PyCFunction)nassl_SSL_set1_sigalgs_list, METH_VARARGS,
+     "OpenSSL's SSL_set1_sigalgs_list()."
     },
     {"get0_verified_chain", (PyCFunction)nassl_SSL_get0_verified_chain, METH_NOARGS,
      "OpenSSL's SSL_get0_verified_chain(). Returns an array of _nassl.X509 objects."

--- a/nassl/_nassl/nassl_SSL.c
+++ b/nassl/_nassl/nassl_SSL.c
@@ -861,6 +861,18 @@ static PyObject* nassl_SSL_set1_sigalgs(nassl_SSL_Object *self, PyObject *args)
 }
 
 
+static PyObject* nassl_get_peer_signature_nid(nassl_SSL_Object *self)
+{
+    int psig_nid;
+
+    if(SSL_get_peer_signature_nid(self->ssl, &psig_nid) != 1)
+    {
+            return raise_OpenSSL_error();
+    }
+    return PyLong_FromUnsignedLong((long)psig_nid);
+}
+
+
 static PyObject* nassl_SSL_get0_verified_chain(nassl_SSL_Object *self, PyObject *args)
 {
     STACK_OF(X509) *verifiedCertChain = NULL;
@@ -1231,6 +1243,9 @@ static PyMethodDef nassl_SSL_Object_methods[] =
     },
     {"set1_sigalgs", (PyCFunction)nassl_SSL_set1_sigalgs, METH_VARARGS,
      "OpenSSL's SSL_set1_sigalgs()."
+    },
+    {"get_peer_signature_nid", (PyCFunction)nassl_get_peer_signature_nid, METH_NOARGS,
+     "OpenSSL's get_peer_signature_nid(). Returns a digest NID"
     },
     {"get0_verified_chain", (PyCFunction)nassl_SSL_get0_verified_chain, METH_NOARGS,
      "OpenSSL's SSL_get0_verified_chain(). Returns an array of _nassl.X509 objects."

--- a/nassl/ephemeral_key_info.py
+++ b/nassl/ephemeral_key_info.py
@@ -12,6 +12,9 @@ class OpenSslEvpPkeyEnum(IntEnum):
     EC = 408
     X25519 = 1034
     X448 = 1035
+    RSA = 6
+    DSA = 116
+    RSA_PSS = 912
 
 
 class OpenSslEcNidEnum(IntEnum):

--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -449,6 +449,10 @@ class SslClient(BaseSslClient):
         # TODO(AD): Eventually merge this method with get/set_cipher_list()
         self._ssl.set_ciphersuites(cipher_suites)
 
+    def set_sigalgs(self, cipher_suites: str) -> None:
+        """Set the enabled signature algorithms, e.g. 'ECDSA+SHA256:RSA+SHA256'"""
+        self._ssl.set1_sigalgs_list(cipher_suites)
+
     def set_groups(self, supported_groups: List[OpenSslEcNidEnum]) -> None:
         """Specify elliptic curves or DH groups that are supported by the client in descending order."""
         self._ssl.set1_groups(supported_groups)

--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -6,7 +6,7 @@ from nassl import _nassl
 from nassl._nassl import WantReadError, OpenSSLError, WantX509LookupError
 
 from enum import IntEnum
-from typing import List, Any
+from typing import List, Any, Tuple
 
 from typing import Protocol
 
@@ -30,6 +30,17 @@ class OpenSslVerifyEnum(IntEnum):
     PEER = 1
     FAIL_IF_NO_PEER_CERT = 2
     CLIENT_ONCE = 4
+
+
+class OpenSslDigestNidEnum(IntEnum):
+    """SSL digest algorithms used for the signature algorithm, per obj_mac.h."""
+
+    MD5 = 4
+    SHA1 = 64
+    SHA224 = 675
+    SHA256 = 672
+    SHA384 = 673
+    SHA512 = 674
 
 
 class OpenSslVersionEnum(IntEnum):
@@ -449,9 +460,10 @@ class SslClient(BaseSslClient):
         # TODO(AD): Eventually merge this method with get/set_cipher_list()
         self._ssl.set_ciphersuites(cipher_suites)
 
-    def set_sigalgs(self, cipher_suites: str) -> None:
-        """Set the enabled signature algorithms, e.g. 'ECDSA+SHA256:RSA+SHA256'"""
-        self._ssl.set1_sigalgs_list(cipher_suites)
+    def set_sigalgs(self, sigalgs: List[Tuple[OpenSslDigestNidEnum, OpenSslEvpPkeyEnum]]) -> None:
+        """Set the enabled signature algorithms for the key exchange."""
+        flattened_sigalgs = [item for sublist in sigalgs for item in sublist]
+        self._ssl.set1_sigalgs(flattened_sigalgs)
 
     def set_groups(self, supported_groups: List[OpenSslEcNidEnum]) -> None:
         """Specify elliptic curves or DH groups that are supported by the client in descending order."""

--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -465,6 +465,10 @@ class SslClient(BaseSslClient):
         flattened_sigalgs = [item for sublist in sigalgs for item in sublist]
         self._ssl.set1_sigalgs(flattened_sigalgs)
 
+    def get_peer_signature_nid(self) -> OpenSslDigestNidEnum:
+        """Get the digest used for TLS message signing."""
+        return OpenSslDigestNidEnum(self._ssl.get_peer_signature_nid())
+
     def set_groups(self, supported_groups: List[OpenSslEcNidEnum]) -> None:
         """Specify elliptic curves or DH groups that are supported by the client in descending order."""
         self._ssl.set1_groups(supported_groups)

--- a/tests/ssl_client_test.py
+++ b/tests/ssl_client_test.py
@@ -217,6 +217,8 @@ class TestModernSslClientOnline:
 
             # And when requesting the verified certificate chain, it returns it
             assert ssl_client.get_verified_chain()
+
+            assert ssl_client.get_peer_signature_nid() == OpenSslDigestNidEnum.SHA256
         finally:
             ssl_client.shutdown()
 


### PR DESCRIPTION
Reference:
https://docs.openssl.org/1.1.1/man3/SSL_CTX_set1_sigalgs/
https://docs.openssl.org/1.1.1/man3/SSL_get_peer_signature_nid/

Some thoughts:
* My C is rusty I have never written CPython before, but I think it's correct.
* The first commit in this PR uses SSL_set1_sigalgs_list() which just takes a string. The final implementation with explicit typing seemed nicer to me.
* Not sure whether this is the right place for these new values/enums, or best naming. Definitely might be a bit sloppy to have non-EC in OpenSslEvpPkeyEnum which lives in ephemeral_key_info.py
* There's some duplication between nassl_SSL_set1_sigalgs and nassl_SSL_set1_groups now. I tried to extract it to python_utils, but felt it was not saving much. Might not be worth it at this time.
