### PR TITLE
New method get_ems_support

### DIFF
--- a/nassl/_nassl/nassl_SSL.c
+++ b/nassl/_nassl/nassl_SSL.c
@@ -304,6 +304,12 @@ static PyObject* nassl_SSL_set1_groups(nassl_SSL_Object *self, PyObject *args)
     PyMem_Free(listOfNids);
     Py_RETURN_NONE;
 }
+
+static PyObject *nassl_SSL_get_extms_support(nassl_SSL_Object *self)
+{
+    long returnValue = SSL_get_extms_support(self->ssl);
+    return Py_BuildValue("l", returnValue);
+}
 #endif
 
 static PyObject* nassl_SSL_shutdown(nassl_SSL_Object *self, PyObject *args)
@@ -1186,6 +1192,9 @@ static PyMethodDef nassl_SSL_Object_methods[] =
     },
     {"set1_groups", (PyCFunction)nassl_SSL_set1_groups, METH_VARARGS,
     "OpenSSL's SSL_set1_groups()"
+    },
+    {"get_extms_support", (PyCFunction)nassl_SSL_get_extms_support, METH_NOARGS,
+    "Returns whether the current session used extended master secret."
     },
 #endif
     {"get_peer_cert_chain", (PyCFunction)nassl_SSL_get_peer_cert_chain, METH_NOARGS,

--- a/nassl/legacy_ssl_client.py
+++ b/nassl/legacy_ssl_client.py
@@ -151,3 +151,7 @@ class LegacySslClient(BaseSslClient):
             except WantX509LookupError:
                 # Server asked for a client certificate and we didn't provide one
                 raise ClientCertificateRequested(self.get_client_CA_list())
+
+    def get_ems_support(self) -> Optional[bool]:
+        """ EMS is not supported by legacy OpenSSL """
+        return None

--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -409,6 +409,14 @@ class BaseSslClient(ABC):
         """
         return [x509.as_pem() for x509 in self._ssl.get_peer_cert_chain()]
 
+    def get_ems_support(self) -> Optional[bool]:
+        support = self._ssl.get_extms_support()
+        if support == 1:
+            return True
+        if support == 0:
+            return False
+        return None
+
 
 class OpenSslEarlyDataStatusEnum(IntEnum):
     """Early data status constants."""


### PR DESCRIPTION
This method checks if current sessions supports Extended Master Secret extension in TLSv1.2 (EMS, [RFC 7627](https://www.ietf.org/rfc/rfc7627.html))

Calls OpenSSL method [SSL_get_extms_support](https://docs.openssl.org/1.1.1/man3/SSL_get_extms_support/).