### PR TITLE
OpenSSL 3 - Add SSL_get0_group_name interface to ssl_client

### DIFF
--- a/nassl/_nassl/nassl_SSL.c
+++ b/nassl/_nassl/nassl_SSL.c
@@ -1150,6 +1150,14 @@ static PyObject *nassl_SSL_get_dh_info(nassl_SSL_Object *self)
     }
 }
 
+#ifdef OPENSSL3
+    static PyObject* nassl_SSL_get0_group_name(nassl_SSL_Object *self, PyObject *args)
+    {
+        const char *groupNameString = SSL_get0_group_name(self->ssl);
+        return PyUnicode_FromString(groupNameString);
+    }
+#endif
+
 static PyMethodDef nassl_SSL_Object_methods[] =
 {
     {"set_bio", (PyCFunction)nassl_SSL_set_bio, METH_VARARGS,
@@ -1269,6 +1277,11 @@ static PyMethodDef nassl_SSL_Object_methods[] =
     {"get_dh_info", (PyCFunction)nassl_SSL_get_dh_info, METH_NOARGS,
      "Returns Diffie-Hellman / Elliptic curve Diffie-Hellman parameters as a dictionary."
     },
+#ifdef OPENSSL3
+    {"get0_group_name", (PyCFunction)nassl_SSL_get0_group_name, METH_NOARGS,
+     "OpenSSL's SSL_get0_group_name(). Returns a string with the negotiated group name."
+    },
+#endif
     {NULL}  // Sentinel
 };
 /*

--- a/nassl/ssl_client.py
+++ b/nassl/ssl_client.py
@@ -481,6 +481,10 @@ class SslClient(BaseSslClient):
         """Specify elliptic curves or DH groups that are supported by the client in descending order."""
         self._ssl.set1_groups(supported_groups)
 
+    def get_group_name(self) -> str:
+        """Get the IANA name of the negotiated group."""
+        return self._ssl.get0_group_name()
+
     def get_verified_chain(self) -> List[str]:
         """Returns the verified PEM-formatted certificate chain.
 


### PR DESCRIPTION
This adds an ssl_client interface for [SSL_get0_group_name](https://docs.openssl.org/3.5/man3/SSL_get0_group_name/), returning the IANA name of the negotiated group. This call is OpenSSL 3 only, so it needs #126 to actually be functional.

My purpose is to determine if the remote server supports (and prefers) PQC, looking at all the [relevant OpenSSL API's](https://docs.openssl.org/3.5/man3/SSL_CTX_set1_curves/), I think this is the best fit.