### PR TITLE
fix(ephemeral_key_info): coerce raw int type/curve to IntEnum (#132)

### DIFF
--- a/nassl/ephemeral_key_info.py
+++ b/nassl/ephemeral_key_info.py
@@ -164,7 +164,7 @@ class EcDhEphemeralKeyInfo(EphemeralKeyInfo):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        # Same int → IntEnum coercion as in the parent — `curve` arrives
+        # Same int → IntEnum coercion as in the parent, `curve` arrives
         # as a raw NID from OpenSSL. Unknown NIDs stay as ints so the
         # "unknown-curve-with-openssl-id-{n}" fallback below still works.
         if not isinstance(self.curve, OpenSslEcNidEnum):

--- a/nassl/ephemeral_key_info.py
+++ b/nassl/ephemeral_key_info.py
@@ -138,6 +138,17 @@ class EphemeralKeyInfo(ABC):
     public_bytes: bytearray
 
     def __post_init__(self) -> None:
+        # `dh_info["type"]` from the C extension is a raw int, so callers
+        # constructing this dataclass via `**dh_info` would otherwise leave
+        # `type` as an int despite the annotation. Coerce here so JSON
+        # serialisation and IntEnum-aware code paths see the expected type.
+        # Unknown values (not in the enum) are left as ints; the type_name
+        # lookup below handles that path with an "UNKNOWN" fallback.
+        if not isinstance(self.type, OpenSslEvpPkeyEnum):
+            try:
+                object.__setattr__(self, "type", OpenSslEvpPkeyEnum(self.type))
+            except ValueError:
+                pass
         # Required because of frozen=True; https://docs.python.org/3/library/dataclasses.html#frozen-instances
         object.__setattr__(
             self,
@@ -153,6 +164,14 @@ class EcDhEphemeralKeyInfo(EphemeralKeyInfo):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        # Same int → IntEnum coercion as in the parent — `curve` arrives
+        # as a raw NID from OpenSSL. Unknown NIDs stay as ints so the
+        # "unknown-curve-with-openssl-id-{n}" fallback below still works.
+        if not isinstance(self.curve, OpenSslEcNidEnum):
+            try:
+                object.__setattr__(self, "curve", OpenSslEcNidEnum(self.curve))
+            except ValueError:
+                pass
         curve_name = _OPENSSL_NID_TO_SECG_ANSI_X9_62.get(self.curve, f"unknown-curve-with-openssl-id-{self.curve}")
         # Required because of frozen=True; https://docs.python.org/3/library/dataclasses.html#frozen-instances
         object.__setattr__(self, "curve_name", curve_name)

--- a/tests/ephemeral_key_info_test.py
+++ b/tests/ephemeral_key_info_test.py
@@ -60,3 +60,28 @@ class TestEphemeralKeyInfo:
         )
         assert key_info
         assert "UNKNOWN" in key_info.type_name
+
+    def test_raw_int_type_is_coerced_to_enum(self) -> None:
+        # Regression for #132: dh_info from the C extension carries raw ints,
+        # so DhEphemeralKeyInfo(**dh_info) used to leave .type as an int.
+        # The dataclass should coerce known values to the IntEnum.
+        key_info = DhEphemeralKeyInfo(
+            type=int(OpenSslEvpPkeyEnum.DH),  # type: ignore
+            size=12,
+            public_bytes=bytearray(b"123"),
+            prime=bytearray(b"123"),
+            generator=bytearray(b"123"),
+        )
+        assert isinstance(key_info.type, OpenSslEvpPkeyEnum)
+        assert key_info.type is OpenSslEvpPkeyEnum.DH
+
+    def test_raw_int_curve_is_coerced_to_enum(self) -> None:
+        # Same coercion for EcDhEphemeralKeyInfo.curve.
+        key_info = EcDhEphemeralKeyInfo(
+            type=int(OpenSslEvpPkeyEnum.EC),  # type: ignore
+            size=12,
+            public_bytes=bytearray(b"123"),
+            curve=int(OpenSslEcNidEnum.X448),  # type: ignore
+        )
+        assert isinstance(key_info.curve, OpenSslEcNidEnum)
+        assert key_info.curve is OpenSslEcNidEnum.X448


### PR DESCRIPTION
## Summary

Fixes #132. ``dh_info`` returned by the C extension carries plain ``int`` values for ``type`` and ``curve``. ``DhEphemeralKeyInfo(**dh_info)`` and friends therefore left those fields as raw ints despite annotations declaring them as ``OpenSslEvpPkeyEnum`` / ``OpenSslEcNidEnum``. The reporter hit this when sslyze tried to JSON-serialise the result and saw ints where IntEnums were expected.

## Change

``nassl/ephemeral_key_info.py``, ``EphemeralKeyInfo.__post_init__`` and ``EcDhEphemeralKeyInfo.__post_init__`` now coerce ``self.type`` / ``self.curve`` to the matching ``IntEnum`` when constructed from a raw int. The coercion is wrapped in a ``try/except ValueError`` so unknown values (the existing ``test_dh_unknown_type`` / ``test_ec_dh_unknown_curve`` shape) keep working with the existing ``UNKNOWN`` / ``unknown-curve-with-openssl-id-{n}`` fallbacks.

This centralises the fix at the dataclass layer (rather than at every call site like the issue's own code sketch), so any future caller using ``**dh_info`` automatically gets the coerced types.

## Test plan

- [x] Manual regression assertions pass on the four shapes (int→known enum coerced, int→unknown left as-is, both for ``type`` and ``curve``)
- [x] New tests in ``tests/ephemeral_key_info_test.py``:
  - ``test_raw_int_type_is_coerced_to_enum``, passes ``type=int(OpenSslEvpPkeyEnum.DH)``, asserts ``isinstance(.type, OpenSslEvpPkeyEnum)``
  - ``test_raw_int_curve_is_coerced_to_enum``, same shape for ``EcDhEphemeralKeyInfo.curve``
- [x] Existing ``test_dh_unknown_type`` and ``test_ec_dh_unknown_curve`` still hold (verified by manual run; the test module's ``SslClient`` import requires the compiled C extension which I can't build locally without OpenSSL deps, but the dataclass paths are exercised directly)